### PR TITLE
Updated deepspeech links for DE-profile

### DIFF
--- a/rhasspyprofile/profiles/de/profile.json
+++ b/rhasspyprofile/profiles/de/profile.json
@@ -90,8 +90,8 @@
                     "kaldi/model/ivectors_test_hires/conf/splice.conf": "synesthesiam/de_kaldi-zamia/acoustic_model/ivectors_test_hires/conf/splice.conf"
                 },
                 "deepspeech": {
-                    "deepspeech/model/0.6.1/alphabet.txt": "de_deepspeech-aashishag/model/alphabet.txt",
-                    "deepspeech/model/0.6.1/output_graph.pb": "de_deepspeech-aashishag/model/output_graph.pb"
+                    "deepspeech/model/0.6.1/alphabet.txt": "synesthesiam/de_deepspeech-aashishag/model/alphabet.txt",
+                    "deepspeech/model/0.6.1/output_graph.pb": "synesthesiam/de_deepspeech-aashishag/model/output_graph.pb"
                 }
             },
             "speech_to_text.pocketsphinx.open_transcription": {
@@ -119,8 +119,8 @@
             },
             "speech_to_text.deepspeech.open_transcription": {
                 "True": {
-                    "deepspeech/model/0.6.1/base_lm.binary": "de_deepspeech-aashishag/model/lm.binary",
-                    "deepspeech/model/0.6.1/base_trie": "de_deepspeech-aashishag/model/trie"
+                    "deepspeech/model/0.6.1/base_lm.binary": "synesthesiam/de_deepspeech-aashishag/model/lm.binary",
+                    "deepspeech/model/0.6.1/base_trie": "synesthesiam/de_deepspeech-aashishag/model/trie"
                 }
             },
             "speech_to_text.pocketsphinx.mix_weight": {
@@ -423,14 +423,14 @@
                 "url": "synesthesiam/de_kaldi-zamia/94960dcb24f8ec2869c1fac451324b6a232afc33/acoustic_model/ivectors_test_hires/conf/splice.conf",
                 "bytes_expected": 35
             },
-            "de_deepspeech-aashishag/model/alphabet.txt": {
+            "synesthesiam/de_deepspeech-aashishag/model/alphabet.txt": {
                 "unzip": false,
-                "url": "de_deepspeech-aashishag/9fe9fbd758b2f775650ad0972710256d65be1317/model/alphabet.txt",
+                "url": "synesthesiam/de_deepspeech-aashishag/9fe9fbd758b2f775650ad0972710256d65be1317/model/alphabet.txt",
                 "bytes_expected": 338
             },
-            "de_deepspeech-aashishag/model/lm.binary": {
+            "synesthesiam/de_deepspeech-aashishag/model/lm.binary": {
                 "unzip": true,
-                "url": "de_deepspeech-aashishag/9fe9fbd758b2f775650ad0972710256d65be1317/model/",
+                "url": "synesthesiam/de_deepspeech-aashishag/9fe9fbd758b2f775650ad0972710256d65be1317/model/",
                 "parts": [
                     {
                         "fragment": "lm.binary.gz.part-00",
@@ -636,9 +636,9 @@
                 "zip_bytes_expected": 1298177007,
                 "bytes_expected": 2063447966
             },
-            "de_deepspeech-aashishag/model/output_graph.pb": {
+            "synesthesiam/de_deepspeech-aashishag/model/output_graph.pb": {
                 "unzip": true,
-                "url": "de_deepspeech-aashishag/9fe9fbd758b2f775650ad0972710256d65be1317/model/",
+                "url": "synesthesiam/de_deepspeech-aashishag/9fe9fbd758b2f775650ad0972710256d65be1317/model/",
                 "parts": [
                     {
                         "fragment": "output_graph.pb.gz.part-00",
@@ -672,15 +672,15 @@
                 "zip_bytes_expected": 175286115,
                 "bytes_expected": 188939504
             },
-            "de_deepspeech-aashishag/model/trie": {
+            "synesthesiam/de_deepspeech-aashishag/model/trie": {
                 "unzip": true,
-                "url": "de_deepspeech-aashishag/9fe9fbd758b2f775650ad0972710256d65be1317/model/trie.gz",
+                "url": "synesthesiam/de_deepspeech-aashishag/9fe9fbd758b2f775650ad0972710256d65be1317/model/trie.gz",
                 "zip_bytes_expected": 12510829,
                 "bytes_expected": 67818944
             },
-            "de_deepspeech-aashishag/base_language_model.fst": {
+            "synesthesiam/de_deepspeech-aashishag/base_language_model.fst": {
                 "unzip": true,
-                "url": "de_deepspeech-aashishag/9fe9fbd758b2f775650ad0972710256d65be1317/base_language_model.fst.gz",
+                "url": "synesthesiam/de_deepspeech-aashishag/9fe9fbd758b2f775650ad0972710256d65be1317/base_language_model.fst.gz",
                 "zip_bytes_expected": 46294251,
                 "bytes_expected": 116125088
             },


### PR DESCRIPTION
In the current configuration the the deepspeech links were pointing to the wrong URL. (Missing /synesthesiam/ as part of it) 
Thus users were unable to download the models/use deepspeech as part of their profile. 

These links are now fixed. 